### PR TITLE
Feat: Add configurable scan interval as number entity

### DIFF
--- a/custom_components/thermoworks_cloud/__init__.py
+++ b/custom_components/thermoworks_cloud/__init__.py
@@ -16,7 +16,7 @@ from .const import DOMAIN
 from .coordinator import ThermoworksCoordinator
 
 # The list of platforms provided by this integration
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.NUMBER]
 
 
 @dataclass

--- a/custom_components/thermoworks_cloud/coordinator.py
+++ b/custom_components/thermoworks_cloud/coordinator.py
@@ -68,6 +68,9 @@ class ThermoworksCoordinator(DataUpdateCoordinator[ThermoworksData]):
         This is the place to pre-process the data to lookup tables
         so entities can quickly look up their data.
         """
+        _LOGGER.debug(
+            "Polling ThermoWorks Cloud API (interval: %s seconds)", self.poll_interval
+        )
 
         try:
             if self.api is None:

--- a/custom_components/thermoworks_cloud/number.py
+++ b/custom_components/thermoworks_cloud/number.py
@@ -1,0 +1,89 @@
+"""Number entity for Thermoworks Cloud integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_SCAN_INTERVAL, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEFAULT_SCAN_INTERVAL_SECONDS, DOMAIN, MIN_SCAN_INTERVAL_SECONDS
+from .coordinator import ThermoworksCoordinator
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number entities for the Thermoworks Cloud integration."""
+    coordinator: ThermoworksCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ].coordinator
+
+    async_add_entities([ScanIntervalNumber(coordinator, config_entry)])
+
+
+class ScanIntervalNumber(CoordinatorEntity[ThermoworksCoordinator], NumberEntity):
+    """Number entity to control the scan interval."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "scan_interval"
+    _attr_native_min_value = MIN_SCAN_INTERVAL_SECONDS
+    _attr_native_max_value = 86400  # 24 hours in seconds
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self, coordinator: ThermoworksCoordinator, config_entry: ConfigEntry
+    ) -> None:
+        """Initialize the scan interval number entity."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{config_entry.entry_id}_scan_interval"
+
+        # Set initial value from options (backward compatible with old config flow)
+        # or use default if not set
+        self._attr_native_value = config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_SECONDS
+        )
+
+    @property
+    def device_info(self):
+        """Return device info for this entity."""
+        # This creates a "virtual" device for the integration itself
+        return {
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
+            "name": "ThermoWorks Cloud",
+            "manufacturer": "ThermoWorks",
+            "model": "Cloud Integration",
+        }
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the scan interval."""
+        new_interval = int(value)
+        _LOGGER.debug("Updating scan interval to %s seconds", new_interval)
+
+        # Update the coordinator's poll interval immediately (no restart needed)
+        self.coordinator.poll_interval = new_interval
+        self.coordinator.update_interval = timedelta(seconds=new_interval)
+
+        # Store the value in config entry options for persistence across restarts
+        # This maintains backward compatibility with the old options flow system
+        new_options = {**self._config_entry.options, CONF_SCAN_INTERVAL: new_interval}
+        self.hass.config_entries.async_update_entry(
+            self._config_entry, options=new_options
+        )
+
+        # Update the entity state
+        self._attr_native_value = new_interval
+        self.async_write_ha_state()
+
+        _LOGGER.info("Scan interval updated to %s seconds", new_interval)

--- a/custom_components/thermoworks_cloud/strings.json
+++ b/custom_components/thermoworks_cloud/strings.json
@@ -31,6 +31,11 @@
       "signal": {
         "name": "[%key:component::sensor::entity_component::signal_strength::name%]"
       }
+    },
+    "number": {
+      "scan_interval": {
+        "name": "Scan interval"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR implements feature request #23 by adding a new number entity that allows users to dynamically adjust the scan interval without restarting Home Assistant.

## Changes
- Added `number.py` with `ScanIntervalNumber` entity that controls polling frequency
- Registered `Platform.NUMBER` in `__init__.py` to enable the number entity
- Added debug logging in `coordinator.py` to track polling intervals
- Added translation strings for the scan_interval number entity
- Maintained backward compatibility with existing options flow configuration

## Benefits
- Users can adjust polling frequency via automations (e.g., faster during cooking, slower when idle)
- Changes take effect immediately without requiring restart
- Existing configurations continue to work without modification

## Testing
- Number entity appears as "Scan interval" under the ThermoWorks Cloud integration device
- Value range: 20 seconds (minimum) to 86400 seconds (24 hours)
- Changes persist across Home Assistant restarts
- Debug logs confirm polling interval updates

I manually tested with some special devcontainer HASS stuff.  I was hoping to commit that too but I couldn't get the HASS container image to reliably come up with the UI.  I got it working once but then I couldn't reproduce it in a way I thought would be valuable to the project.  The Thermoworks component was working, I the python requirements for the image were just being weird.

Here I will post some redacted logs
```
  # Initial setup with default 30-minute interval (1800 seconds)
  2025-12-15 00:11:05.978 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 1800 seconds)
  2025-12-15 00:11:06.754 DEBUG (MainThread) [custom_components.thermoworks_cloud] Retrieved 5 devices for user
  2025-12-15 00:11:09.882 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved
  2025-12-15 00:11:09.897 INFO (MainThread) [homeassistant.components.number] Setting up thermoworks_cloud.number

  # User changes interval to 5 seconds - immediate effect without restart
  2025-12-15 00:11:34.957 DEBUG (MainThread) [custom_components.thermoworks_cloud] Updating scan interval to 5 seconds
  2025-12-15 00:11:34.993 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 5 seconds)
  2025-12-15 00:11:35.005 INFO (MainThread) [custom_components.thermoworks_cloud] Scan interval updated to 5 seconds
  2025-12-15 00:11:35.753 DEBUG (MainThread) [custom_components.thermoworks_cloud] Retrieved 5 devices for user
  2025-12-15 00:11:38.770 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved

  # Polling occurs every 5 seconds as configured
  2025-12-15 00:11:43.995 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 5 seconds)
  2025-12-15 00:11:47.325 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved
  2025-12-15 00:11:51.990 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 5 seconds)
  2025-12-15 00:11:54.432 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved

  # User changes interval to 60 seconds - immediate effect
  2025-12-15 00:12:10.583 DEBUG (MainThread) [custom_components.thermoworks_cloud] Updating scan interval to 60 seconds
  2025-12-15 00:12:10.594 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 60 seconds)
  2025-12-15 00:12:10.596 INFO (MainThread) [custom_components.thermoworks_cloud] Scan interval updated to 60 seconds
  2025-12-15 00:12:11.186 DEBUG (MainThread) [custom_components.thermoworks_cloud] Retrieved 5 devices for user
  2025-12-15 00:12:13.301 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved

  # Polling now occurs every 60 seconds
  2025-12-15 00:13:12.826 INFO (MainThread) [custom_components.thermoworks_cloud] Polling ThermoWorks Cloud API (interval: 60 seconds)
  2025-12-15 00:13:16.268 DEBUG (MainThread) [custom_components.thermoworks_cloud] Update completed: 5 devices with data retrieved
```

Resolves #23