### PR TITLE
Add ETI Cloud support alongside ThermoWorks

### DIFF
--- a/custom_components/thermoworks_cloud/config_flow.py
+++ b/custom_components/thermoworks_cloud/config_flow.py
@@ -14,9 +14,28 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from thermoworks_cloud import AuthenticationError, AuthFactory, ThermoworksCloud
 
-from .const import DEFAULT_SCAN_INTERVAL_SECONDS, DOMAIN, MIN_SCAN_INTERVAL_SECONDS
+from .const import (
+    CLOUD_PROVIDERS,
+    CONF_CLOUD_PROVIDER,
+    DEFAULT_SCAN_INTERVAL_SECONDS,
+    DOMAIN,
+    MIN_SCAN_INTERVAL_SECONDS,
+    PROVIDER_ETI,
+    PROVIDER_THERMOWORKS,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+PROVIDER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CLOUD_PROVIDER, default=PROVIDER_THERMOWORKS): vol.In(
+            {
+                PROVIDER_THERMOWORKS: "ThermoWorks Cloud (US)",
+                PROVIDER_ETI: "ETI Cloud (UK/International)",
+            }
+        ),
+    }
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -26,14 +45,25 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from THERMOWORKS_CLOUD_SCHEMA with values provided by the user.
-
-    """
+def _build_auth_factory(
+    hass: HomeAssistant, provider: str
+) -> AuthFactory:
+    """Build an AuthFactory for the given cloud provider."""
     client_session = async_get_clientsession(hass)
-    auth_factory = AuthFactory(client_session)
+    provider_config = CLOUD_PROVIDERS[provider]
+    return AuthFactory(
+        client_session,
+        api_key=provider_config["api_key"],
+        app_id=provider_config["app_id"],
+        referer=provider_config["referer"],
+    )
+
+
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any], provider: str
+) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    auth_factory = _build_auth_factory(hass, provider)
     try:
         auth = await auth_factory.build_auth(
             data[CONF_EMAIL], password=data[CONF_PASSWORD]
@@ -46,8 +76,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     except ConnectionError as e:
         raise CannotConnect from e
 
-    # Return info that you want to store in the config entry.
-    return {"title": "ThermoWorks Cloud", "user": auth.user_id}
+    provider_name = CLOUD_PROVIDERS[provider]["name"]
+    return {"title": provider_name, "user": auth.user_id}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -55,6 +85,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     _input_data: dict[str, Any]
+    _provider: str = PROVIDER_THERMOWORKS
 
     @staticmethod
     @callback
@@ -67,11 +98,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Handle the initial step."""
+        """Handle the cloud provider selection step."""
+        if user_input is not None:
+            self._provider = user_input[CONF_CLOUD_PROVIDER]
+            return await self.async_step_credentials()
+
+        return self.async_show_form(
+            step_id="user", data_schema=PROVIDER_SCHEMA
+        )
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle the credentials step."""
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await validate_input(self.hass, user_input, self._provider)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -81,14 +124,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                # Validation was successful, so create a unique id for this instance of your integration
-                # and create the config entry.
                 await self.async_set_unique_id(info.get("user"))
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
+                entry_data = {
+                    **user_input,
+                    CONF_CLOUD_PROVIDER: self._provider,
+                }
+                return self.async_create_entry(title=info["title"], data=entry_data)
 
         return self.async_show_form(
-            step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
+            step_id="credentials", data_schema=CONFIG_SCHEMA, errors=errors
         )
 
 
@@ -101,9 +146,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             options = self.config_entry.options | user_input
             return self.async_create_entry(data=options)
 
-        # It is recommended to prepopulate options fields with default values if available.
-        # These will be the same default values you use on your coordinator for setting variable values
-        # if the option has not been set.
         data_schema = vol.Schema(
             {
                 vol.Required(

--- a/custom_components/thermoworks_cloud/const.py
+++ b/custom_components/thermoworks_cloud/const.py
@@ -5,3 +5,23 @@ DOMAIN = "thermoworks_cloud"
 DEFAULT_SCAN_INTERVAL_SECONDS = 1800
 # Just an arbitrary value
 MIN_SCAN_INTERVAL_SECONDS = 5
+
+CONF_CLOUD_PROVIDER = "cloud_provider"
+
+PROVIDER_THERMOWORKS = "thermoworks"
+PROVIDER_ETI = "eti"
+
+CLOUD_PROVIDERS = {
+    PROVIDER_THERMOWORKS: {
+        "name": "ThermoWorks Cloud",
+        "api_key": None,  # Use library defaults
+        "app_id": None,
+        "referer": None,
+    },
+    PROVIDER_ETI: {
+        "name": "ETI Cloud",
+        "api_key": "AIzaSyBD4snlT2LllO4k0NywX5qYjJ7M7WfU4_I",
+        "app_id": "1:701566661301:web:7a9bc711c05985ead144fc",
+        "referer": "https://cloud.etiltd.com/",
+    },
+}

--- a/custom_components/thermoworks_cloud/coordinator.py
+++ b/custom_components/thermoworks_cloud/coordinator.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from thermoworks_cloud import AuthFactory, ThermoworksCloud, ResourceNotFoundError
 
-from .const import DEFAULT_SCAN_INTERVAL_SECONDS, DOMAIN
+from .const import (
+    CLOUD_PROVIDERS,
+    CONF_CLOUD_PROVIDER,
+    DEFAULT_SCAN_INTERVAL_SECONDS,
+    DOMAIN,
+    PROVIDER_THERMOWORKS,
+)
 from .exceptions import MissingRequiredAttributeError
 from .models import ThermoworksDevice, ThermoworksChannel
 
@@ -59,7 +65,14 @@ class ThermoworksCoordinator(DataUpdateCoordinator[ThermoworksData]):
             update_interval=timedelta(seconds=self.poll_interval),
         )
         client_session = async_get_clientsession(hass)
-        self.auth_factory = AuthFactory(client_session)
+        provider = config_entry.data.get(CONF_CLOUD_PROVIDER, PROVIDER_THERMOWORKS)
+        provider_config = CLOUD_PROVIDERS[provider]
+        self.auth_factory = AuthFactory(
+            client_session,
+            api_key=provider_config["api_key"],
+            app_id=provider_config["app_id"],
+            referer=provider_config["referer"],
+        )
         self.api = None
 
     async def async_update_data(self) -> ThermoworksData:

--- a/custom_components/thermoworks_cloud/manifest.json
+++ b/custom_components/thermoworks_cloud/manifest.json
@@ -14,7 +14,7 @@
     "thermoworks_cloud"
   ],
   "requirements": [
-    "thermoworks_cloud==0.1.12"
+    "thermoworks-cloud @ git+https://github.com/rathga/python-thermoworks-cloud.git@main"
   ],
   "single_config_entry": false,
   "ssdp": [],

--- a/custom_components/thermoworks_cloud/manifest.json
+++ b/custom_components/thermoworks_cloud/manifest.json
@@ -14,7 +14,7 @@
     "thermoworks_cloud"
   ],
   "requirements": [
-    "thermoworks-cloud @ git+https://github.com/rathga/python-thermoworks-cloud.git@main"
+    "thermoworks_cloud==0.1.13"
   ],
   "single_config_entry": false,
   "ssdp": [],

--- a/custom_components/thermoworks_cloud/strings.json
+++ b/custom_components/thermoworks_cloud/strings.json
@@ -2,6 +2,14 @@
   "config": {
     "step": {
       "user": {
+        "title": "Cloud Provider",
+        "description": "Select which cloud platform your devices are registered with.",
+        "data": {
+          "cloud_provider": "Cloud Provider"
+        }
+      },
+      "credentials": {
+        "title": "Account Credentials",
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/custom_components/thermoworks_cloud/translations/en.json
+++ b/custom_components/thermoworks_cloud/translations/en.json
@@ -1,4 +1,30 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "title": "Cloud Provider",
+        "description": "Select which cloud platform your devices are registered with.",
+        "data": {
+          "cloud_provider": "Cloud Provider"
+        }
+      },
+      "credentials": {
+        "title": "Account Credentials",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Account is already configured"
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -6,7 +32,7 @@
           "scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "scan_interval": "How often to poll ThermoWorks for updates"
+          "scan_interval": "How often to poll for updates"
         }
       }
     }


### PR DESCRIPTION
## Summary

- Adds a cloud provider selection step to the config flow (ThermoWorks Cloud / ETI Cloud)
- Passes the appropriate Firebase credentials to `AuthFactory` based on user selection
- Stores provider choice in the config entry for use during coordinator initialization

## Motivation

ETI Ltd is ThermoWorks' UK/international partner company. They share identical hardware (RFX Gateway, RFX Meat probes, Signals, BlueDOT, etc.) but run a separate Firebase cloud platform at `cloud.etiltd.com`. UK users who pair devices via the ETI app currently have no Home Assistant integration available.

Since the Firestore schema, auth flow, and device data structures are identical, adding ETI Cloud support requires only passing different Firebase credentials — no changes to data parsing or sensor logic.

## Dependencies

This PR depends on [python-thermoworks-cloud#18](https://github.com/a2hill/python-thermoworks-cloud/pull/18) which makes `AuthFactory` accept configurable credentials. The `manifest.json` requirements will need updating to point to the released version of that library once merged.

## Changes

- **`const.py`** — Added cloud provider constants and credential configurations for ThermoWorks and ETI Cloud
- **`config_flow.py`** — Added a provider selection step (`async_step_user`) before the credentials step (`async_step_credentials`); `validate_input` now accepts a provider parameter
- **`coordinator.py`** — Reads provider from config entry data and passes appropriate credentials to `AuthFactory`
- **`strings.json`** / **`translations/en.json`** — Added UI strings for the provider selection and credentials steps
- **`manifest.json`** — Updated requirements to use the configurable library (will be updated to a PyPI version once the library PR is released)

## Backward Compatibility

- Existing ThermoWorks-only config entries default to `PROVIDER_THERMOWORKS` if `cloud_provider` is not present in the entry data, so existing installations continue working
- ThermoWorks Cloud credentials are the library defaults, so the ThermoWorks path is unchanged

## Test plan

- [x] Verified ETI Cloud end-to-end: provider selection → credentials → authentication → device discovery → sensor entities with live temperature data from RFX Gateway and RFX Meat probes
- [x] Config flow shows both provider options correctly
- [x] Integration state shows as "loaded" with all sensors reporting

🤖 Generated with [Claude Code](https://claude.ai/claude-code)